### PR TITLE
add diff mode to sort-qif.pl

### DIFF
--- a/bin/sort-qif.pl
+++ b/bin/sort-qif.pl
@@ -9,11 +9,14 @@
 
 use strict;
 use warnings;
+use Fcntl qw(F_SETFD);
+use File::Temp qw(tempfile);
 use Getopt::Long;
 
-my ($strip_comments, $http);
+my ($diff_mode, $strip_comments, $http);
 
 GetOptions(
+    "diff"           => \$diff_mode,
     "strip-comments" => \$strip_comments,
     "http"           => \$http,
     "help"           => sub {
@@ -21,6 +24,7 @@ GetOptions(
 Usage $0 [options] [files]
 
 Options:
+  --diff            diff mode; takes two files as arguments and runs `diff -u`
   --strip-comments  strips comments
   --http            moves pseudo headers and content-length to the top of each
                     header block
@@ -30,32 +34,56 @@ EOT
     },
 ) or die "error in command line arguments\n";
 
+if ($diff_mode) {
+    die "diff mode excepts two arguments (filenames)\n"
+        if @ARGV != 2;
+    my @tmpfds = map {
+        my $qif = filter($_);
+        my $fh = tempfile();
+        print $fh $qif;
+        seek $fh, 0, 0;
+        fcntl $fh, F_SETFD, 0
+            or die "failed to clear O_CLOEXEC of temporary file:$!";
+        $fh;
+    } @ARGV;
+    exec 'diff', '-u', map { '/dev/fd/' . fileno $_ } @tmpfds;
+    die "failed to execute diff:$!";
+} else {
+    print filter($_)
+        for @ARGV;
+}
 
-my @chunks = do {
-    local $/ = "\n\n";
-    map { $$_[1] }
-        sort { $$a[0] <=> $$b[0] }
-        map { /^#\s*stream\s+(\d+)/; [ $1 || 0, $_ ] }
-        <>;
-};
+# reads given qif file and returns the filtered output as a string
+sub filter {
+    my $fn = shift;
+    my @chunks = do {
+        open my $fh, "<", $fn
+            or die "failed to open file:$fn:$!";
+        local $/ = "\n\n";
+        map { $$_[1] }
+            sort { $$a[0] <=> $$b[0] }
+            map { /^#\s*stream\s+(\d+)/; [ $1 || 0, $_ ] }
+            <$fh>;
+    };
 
-if ($strip_comments) {
-    for (@chunks) {
-        s/^#.*\n//mg;
+    if ($strip_comments) {
+        for (@chunks) {
+            s/^#.*\n//mg;
+        }
     }
-}
 
-if ($http) {
-    @chunks = map {
-        my @in = split /\n/, $_;
-        my @out = (
-            (grep { /^#/ } @in),
-            (sort grep { /^:/ } @in),
-            (sort grep { /^content-length\s/ } @in),
-            (grep { !/^(?:#|:|content-length\s|$)/ } @in),
-        );
-        (join "\n", @out) . "\n\n";
-    } @chunks;
-}
+    if ($http) {
+        @chunks = map {
+            my @in = split /\n/, $_;
+            my @out = (
+                (grep { /^#/ } @in),
+                (sort grep { /^:/ } @in),
+                (sort grep { /^content-length\s/ } @in),
+                (grep { !/^(?:#|:|content-length\s|$)/ } @in),
+            );
+            (join "\n", @out) . "\n\n";
+        } @chunks;
+    }
 
-print @chunks;
+    join "", @chunks;
+}


### PR DESCRIPTION
As discussed in README.md, comparing two qifs hasn't been an easy task.  This PR solves the issue by adding `--diff` option to sort-qif.pl.

Now, instead of doing something like:
```
diff <(sort-qif.pl --strip-comments a.qif) <(sort-qif.pl --strip-comments b.qif)
```
you can simply do:
```
sort-qif.pl --diff --strip-comments a.qif b.qif
```

It can also be used to pass other flags that affect the sorting logic (i.e. `sort-qif.pl --diff --http a.qif b.qif` can be used for comparing the output of h2o).